### PR TITLE
Modify transfer_kind to be compatible with AssetHub transfer 

### DIFF
--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -674,10 +674,10 @@ pub mod module {
 			// Check dest and reserve, in case dest is AssetHub and reserve is parent, 
 			// we change transfer_kind to "ToReserve".
 			let is_asset_hub_dest = dest.chain_part().unwrap_or(Location::parent()) == Location::new(1, [Parachain(1000)]) || dest == Location::new(1, [Parachain(1001)]);
-			let transfer_kind = if is_asset_hub_dest && reserve == Location::parent() {
-				TransferKind::ToReserve
+			let (transfer_kind, reserve) = if is_asset_hub_dest && reserve == Location::parent() {
+				(TransferKind::ToReserve, dest.chain_part().unwrap_or(Location::parent()))
 			} else {
-				transfer_kind
+				(transfer_kind, reserve)
 			};
 
 			let mut msg = match transfer_kind {

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -674,7 +674,7 @@ pub mod module {
 			// Check dest and reserve, in case dest is AssetHub and reserve is parent, 
 			// we change transfer_kind to "ToReserve".
 			let dest_chain_part = dest.chain_part().ok_or(Error::<T>::InvalidDest)?;
-			let is_asset_hub_dest = dest_chain_part  == Location::new(1, [Parachain(1000)]) || dest_chain_part == Location::new(1, [Parachain(1001)]);
+			let is_asset_hub_dest = dest_chain_part == Location::new(1, [Parachain(1000)]) || dest_chain_part == Location::new(1, [Parachain(1001)]);
 			let transfer_kind = if is_asset_hub_dest && reserve == Location::parent() {
 				TransferKind::ToReserve
 			} else {

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -673,11 +673,12 @@ pub mod module {
 
 			// Check dest and reserve, in case dest is AssetHub and reserve is parent, 
 			// we change transfer_kind to "ToReserve".
-			let is_asset_hub_dest = dest.chain_part().unwrap_or(Location::parent()) == Location::new(1, [Parachain(1000)]) || dest == Location::new(1, [Parachain(1001)]);
-			let (transfer_kind, reserve) = if is_asset_hub_dest && reserve == Location::parent() {
-				(TransferKind::ToReserve, dest.chain_part().unwrap_or(Location::parent()))
+			let dest_chain_part = dest.chain_part().ok_or(Error::<T>::InvalidDest)?;
+			let is_asset_hub_dest = dest_chain_part  == Location::new(1, [Parachain(1000)]) || dest_chain_part == Location::new(1, [Parachain(1001)]);
+			let transfer_kind = if is_asset_hub_dest && reserve == Location::parent() {
+				TransferKind::ToReserve
 			} else {
-				(transfer_kind, reserve)
+				transfer_kind
 			};
 
 			let mut msg = match transfer_kind {

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -670,6 +670,16 @@ pub mod module {
 				Some(recipient) => recipient,
 				None => recipient,
 			};
+
+			// Check dest and reserve, in case dest is AssetHub and reserve is parent, 
+			// we change transfer_kind to "ToReserve".
+			let is_asset_hub_dest = dest == Location::new(1, [Parachain(1000)]) || dest == Location::new(1, [Parachain(1001)]);
+			let transfer_kind = if is_asset_hub_dest && reserve == Location::parent() {
+				TransferKind::ToReserve
+			} else {
+				transfer_kind
+			};
+
 			let mut msg = match transfer_kind {
 				SelfReserveAsset => Self::transfer_self_reserve_asset(assets, fee, dest, recipient, dest_weight_limit)?,
 				ToReserve => Self::transfer_to_reserve(assets, fee, dest, recipient, dest_weight_limit)?,

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -673,7 +673,7 @@ pub mod module {
 
 			// Check dest and reserve, in case dest is AssetHub and reserve is parent, 
 			// we change transfer_kind to "ToReserve".
-			let is_asset_hub_dest = dest == Location::new(1, [Parachain(1000)]) || dest == Location::new(1, [Parachain(1001)]);
+			let is_asset_hub_dest = dest.chain_part().unwrap_or(Location::parent()) == Location::new(1, [Parachain(1000)]) || dest == Location::new(1, [Parachain(1001)]);
 			let transfer_kind = if is_asset_hub_dest && reserve == Location::parent() {
 				TransferKind::ToReserve
 			} else {


### PR DESCRIPTION
Modifies some code present in `execute_and_send_reserve_kind_xcm` function of `Xtokens` pallet, for DOTs transfers (from Moonbeam to AssetHub) to work properly.